### PR TITLE
Add additional information in generating output file and add sf and input_dir to runners setup function

### DIFF
--- a/benchmark/duckdb/benchmark.py
+++ b/benchmark/duckdb/benchmark.py
@@ -20,6 +20,7 @@ class Arguments:
     use_generic_device: bool = False
     benchmark: str = ""
     mount_path: str = None
+    input_dir: str = "./"
 
     def valid(self) -> bool:
         print(self)
@@ -102,6 +103,14 @@ class Arguments:
             default=None
         )
 
+        parser.add_argument(
+            "-i",
+            "--input_directory",
+            type=str,
+            help="Input directory to use for the benchmark. That is the place where data files are stored and can data can be loaded from",
+            default="./"
+        )
+
         args = parser.parse_args()
         
         arguments: Arguments = Arguments(
@@ -113,7 +122,8 @@ class Arguments:
             use_fdp=args.fdp,
             use_generic_device=args.generic_device,
             benchmark=args.benchmark,
-            mount_path=args.mount_path
+            mount_path=args.mount_path,
+            input_dir=args.input_directory
         )
 
         if not arguments.valid():
@@ -202,7 +212,6 @@ def start_device_measurements(device: NvmeDevice, file_name: str):
 
     return stop_measurement
 
-
 if __name__ == "__main__":
 
     args: Arguments = Arguments.parse_args()
@@ -218,7 +227,7 @@ if __name__ == "__main__":
     # Setup the database with the correct device config
     db, device = setup_device_and_db(args.buffer_manager_mem_size)
 
-    setup_benchmark(db)
+    setup_benchmark(db, args.input_dir, args.scale_factor)
 
     # NOTE: The connection is not thread-safe, search for duckdb cursor in the client library to see how to use in a multi-threaded environment
     stop_measurement = start_device_measurements(device, device_output_file)

--- a/benchmark/duckdb/benchmark.py
+++ b/benchmark/duckdb/benchmark.py
@@ -159,6 +159,7 @@ def prepare_setup_func(args: Arguments) -> SetupFunc:
     
     def setup_normal(buffer_manager_size: int):
 
+        setup_device(device, mount_path=args.mount_path)
         db: duckdb.Database = duckdb.connect("bench.db")
         db.query(f"SET memory_limit='{buffer_manager_size}MB';")
         db.query("SET threads=1;")

--- a/benchmark/duckdb/benchmark.py
+++ b/benchmark/duckdb/benchmark.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
     setup_device_and_db = prepare_setup_func(args)
 
     fdp_name = "fdp" if args.use_fdp else "nofdp"
-    name = f"duckdb-bench-{args.io_backend}-{args.scale_factor}-{fdp_name}" 
+    name = f"duckdb-{args.benchmark}-mem{args.buffer_manager_mem_size}-{args.io_backend}-sf{args.scale_factor}-{fdp_name}" 
     device_output_file = f"{name}-device.csv"
     output_file = f"{name}.csv"
 

--- a/benchmark/duckdb/benchmark.py
+++ b/benchmark/duckdb/benchmark.py
@@ -152,6 +152,7 @@ def prepare_setup_func(args: Arguments) -> SetupFunc:
             args.use_fdp)
         db = duckdb.connect("nvmefs:///bench.db", config)
         db.query(f"SET memory_limit='{buffer_manager_size}MB';")
+        db.query("SET threads=1;")
         db.query("PRAGMA disable_object_cache;")
 
         return db, device
@@ -160,6 +161,7 @@ def prepare_setup_func(args: Arguments) -> SetupFunc:
 
         db: duckdb.Database = duckdb.connect("bench.db")
         db.query(f"SET memory_limit='{buffer_manager_size}MB';")
+        db.query("SET threads=1;")
         db.query("PRAGMA disable_object_cache;")
 
         return db, device

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 DURATION=20
 DEVICE="/dev/nvme1"
+INPUT_DIR="/home/pinar"
 
 source ./init.sh
 
 # Run the benchmark with the generic device, io_uring_cmd, and fdp
-python3 benchmark.py -d $DURATION --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 5120 --fdp tpch
+python3 benchmark.py -d $DURATION --sf 1 --input_dir $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 5120 --fdp tpch
 
 # Run the benchmark with the generic device, io_uring_cmd, but without fdp
 # python3 benchmark.py -i $DURATION -d $DEVICE --generic_device -b "io_uring_cmd" tpch

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -6,7 +6,7 @@ INPUT_DIR="/home/pinar"
 source ./init.sh
 
 # Run the benchmark with the generic device, io_uring_cmd, and fdp
-python3 benchmark.py -d $DURATION --sf 1 --input_dir $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 5120 --fdp tpch
+python3 benchmark.py -d $DURATION --sf 1 --input_dir $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 80 --fdp tpch
 
 # Run the benchmark with the generic device, io_uring_cmd, but without fdp
 # python3 benchmark.py -i $DURATION -d $DEVICE --generic_device -b "io_uring_cmd" tpch

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-DURATION=20
+DURATION=60
 DEVICE="/dev/nvme1"
 INPUT_DIR="/home/pinar"
+MOUNT="/mnt/itu/duckdb"
 
+source /home/pinar/.bashrc
 source ./init.sh
 
 # Run the benchmark with the generic device, io_uring_cmd, and fdp
-python3 benchmark.py -d $DURATION --sf 1 --input_dir $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 80 --fdp tpch
+python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 75 --fdp tpch
 
 # Run the benchmark with the generic device, io_uring_cmd, but without fdp
 # python3 benchmark.py -i $DURATION -d $DEVICE --generic_device -b "io_uring_cmd" tpch
@@ -15,4 +17,4 @@ python3 benchmark.py -d $DURATION --sf 1 --input_dir $INPUT_DIR --device_path $D
 # python3 benchmark.py -i $DURATION -d $DEVICE -b "io_uring" tpch
 
 # Run regular benchmark with default file system(could be a base line)
-# python3 benchmark.py -i $DURATION tpch
+python3 benchmark.py -d $DURATION --mount_path $MOUNT --input_directory $INPUT_DIR tpch

--- a/benchmark/duckdb/runner/README.md
+++ b/benchmark/duckdb/runner/README.md
@@ -1,0 +1,19 @@
+# Benchmark Runners
+
+This directory contains the interfaces and implementations required by `../benchmark.py` to execute benchmarks for DuckDB. It provides a factory to create the appropriate benchmark setup functions and runners, ensuring a modular and extensible design for benchmarking.
+
+## Purpose
+
+The benchmark runners in this directory are responsible for:
+- Setting up the environment for each benchmark.
+- Executing the benchmarks with the specified configurations.
+- Collecting and reporting results in a standardized format(csv).
+
+These runners are designed to integrate seamlessly with the `../benchmark.py` script, which orchestrates the overall benchmarking process.
+
+## Implemented Benchmarks
+
+The following benchmarks are implemented in this directory:
+- **TPCH Benchmark**: Executes the TPC-H queries to evaluate performance on analytical workloads.
+
+Each benchmark is implemented with a corresponding runner and setup function, ensuring flexibility and reusability.

--- a/benchmark/duckdb/runner/benchmark_types.py
+++ b/benchmark/duckdb/runner/benchmark_types.py
@@ -4,4 +4,4 @@ from database.duckdb import Database
 
 type BenchmarkRunnerFunc = Callable[[Database, int], list[str]]
 type BenchmarkEpochFunc = Callable[[Database], list[str]]
-type BenchmarkSetupFunc = Callable[[Database], None]
+type BenchmarkSetupFunc = Callable[[Database, str, int], None]

--- a/benchmark/duckdb/runner/tpch.py
+++ b/benchmark/duckdb/runner/tpch.py
@@ -1,16 +1,18 @@
+import os
 import time
 from database.duckdb import Database
 
 TPCH_BENCHMARK_NAME = "tpch"
 
-def setup_tpch_benchmark(db: Database):
-    # TODO: Load the tpch extension to be used when running the benchmarks
+def setup_tpch_benchmark(db: Database, input_dir_path: str, scale_factor: int):
+    input_file_path = os.path.join(input_dir_path, f"tpch-{scale_factor}.db")
+
     db.add_extension("tpch")
 
-    # db.query("ATTACH DATABASE 'tpch-1.db' AS tpch (READ_WRITE);") # TODO: Add parameter with file to copy data from
-    # db.query("COPY FROM DATABASE tpch TO bench;")
-    # db.query("DETACH DATABASE tpch;")
-    db.query("CALL dbgen(sf=1);")
+    db.query(f"ATTACH DATABASE '{input_file_path}' AS tpch (READ_WRITE);")
+    db.query("COPY FROM DATABASE tpch TO bench;")
+    db.query("DETACH DATABASE tpch;")
+    # db.query("CALL dbgen(sf=1);")
 
 def run_tpch_epoch_benchmark(db: Database):
 
@@ -24,9 +26,6 @@ def run_tpch_epoch_benchmark(db: Database):
         # Get query elapsed time in milliseconds
         query_elapsed = (end - start) * 1000
 
-        # TODO: Add other metrics to the results?
         results.append(f"{query_nr};{query_elapsed}\n")
-
-        # TODO: Can we add query result verification???
 
     return results


### PR DESCRIPTION
I was supposed to add an additional argument. But i noticed that we instead could just extend what was previously outputted to contain additional output metrics.
Additionally, we have added more parameters to the benchmark runner setup function such that data can be fetched based on scale factor and input path.
