### PR TITLE
Add more benchmarks for duckdb

### DIFF
--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-DURATION=60
+DURATION=180
+READ_DURATION=30
 DEVICE="/dev/nvme1"
 INPUT_DIR="/home/pinar"
 MOUNT="/mnt/itu/duckdb"
@@ -7,11 +8,14 @@ MOUNT="/mnt/itu/duckdb"
 source /home/pinar/.bashrc
 source ./init.sh
 
-# Run the benchmark with the generic device, io_uring_cmd, and fdp
-python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 75 --fdp tpch
+# Run benchmarks with enough main memory to not make it spill to disk
+python3 benchmark.py -d $READ_DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 50000 tpch
+python3 benchmark.py -d $READ_DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 50000 --fdp tpch
+python3 benchmark.py -d $DURATION --mount_path $MOUNT --device_path $DEVICE --input_directory $INPUT_DIR -m 50000 tpch
 
-# Run the benchmark with the generic device, io_uring_cmd, but without fdp
-# python3 benchmark.py -i $DURATION -d $DEVICE --generic_device -b "io_uring_cmd" tpch
+# Run the benchmark with the generic device, io_uring_cmd, and fdp
+python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 75 tpch
+python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 75 --fdp tpch
 
 # Run the benchmark with the nvme block device(e.g. /dev/nvme1n1) using io_uring
 # python3 benchmark.py -i $DURATION -d $DEVICE -b "io_uring" tpch


### PR DESCRIPTION

We add:
- Benchmarks that only test read. That is queries with no disk spilling
- Benchmarks that use fdp and no fdp