### PR TITLE
Add precondition of device

### DIFF
--- a/benchmark/duckdb/benchmark.py
+++ b/benchmark/duckdb/benchmark.py
@@ -140,7 +140,7 @@ def prepare_setup_func(args: Arguments) -> SetupFunc:
 
     device = NvmeDevice(args.device)
     def setup_nvme():
-        device_namespace = setup_device(device, enable_fdp=args.use_fdp)
+        device_namespace = setup_device(device, namespace_id=2, enable_fdp=args.use_fdp)
         device_path = device_namespace.get_generic_device_path() if args.use_generic_device else device_namespace.get_device_path()
 
         print(f"Using device path: {device_path}")
@@ -160,7 +160,7 @@ def prepare_setup_func(args: Arguments) -> SetupFunc:
 
         normal_db_path = os.path.join(args.mount_path, "bench.db")
 
-        setup_device(device, mount_path=args.mount_path)
+        setup_device(device, namespace_id=2, mount_path=args.mount_path)
         db: duckdb.Database = duckdb.connect(normal_db_path)
 
         return db, device

--- a/benchmark/duckdb/benchmark.py
+++ b/benchmark/duckdb/benchmark.py
@@ -175,7 +175,7 @@ def start_device_measurements(device: NvmeDevice, file_name: str):
 
     def run(device: NvmeDevice, file: str):
         os.system("sync")
-        previous_host_written, previous_media_written = device.get_written_bytes_nsid(1)
+        previous_host_written, previous_media_written = device.get_written_bytes_nsid(2)
         global RUN_MEASUREMENT
 
         waf_file = open(file, "w+", newline="\n")
@@ -183,7 +183,7 @@ def start_device_measurements(device: NvmeDevice, file_name: str):
         while RUN_MEASUREMENT:
             time.sleep(600)
             os.system("sync")
-            host_written, media_written = device.get_written_bytes_nsid(1)
+            host_written, media_written = device.get_written_bytes_nsid(2)
             if host_written == 0:
                 continue
 

--- a/benchmark/duckdb/device/nvme.py
+++ b/benchmark/duckdb/device/nvme.py
@@ -247,10 +247,10 @@ def setup_device(device: NvmeDevice, namespace_id:int = 1, enable_fdp: bool = Fa
         device.delete_namespace_nsid(namespace_id)
     
     # Ensure that FDP is enabled / disabled
-    if enable_fdp:
-        device.enable_fdp()
-    else:
-        device.disable_fdp()
+    # if enable_fdp:
+    #     device.enable_fdp()
+    # else:
+    #     device.disable_fdp()
     
     # Create new namespace with a new configuration
     return device.create_namespace(device.base_device_path, namespace_id, enable_fdp, mount_path=mount_path, size=size)

--- a/benchmark/duckdb/device/nvme.py
+++ b/benchmark/duckdb/device/nvme.py
@@ -169,8 +169,9 @@ class NvmeDevice:
         result = 1
         ns_number_of_blocks = int(self.number_of_blocks*size)
         
+        print(f"Creating namespace {namespace_id} with {ns_number_of_blocks} blocks")
         if enable_fdp:
-            result = os.system(f"nvme create-ns {device_path} -b {self.block_size} --nsze={ns_number_of_blocks} --ncap={ns_number_of_blocks} --nphndls=7 --phndls=0,1,2,3,4,5,6")
+            result = os.system(f"nvme create-ns {device_path} -b {self.block_size} --nsze={ns_number_of_blocks} --ncap={ns_number_of_blocks} --nphndls=6 --phndls=0,1,2,3,4,5")
         else: 
             result = os.system(f"nvme create-ns {device_path} -b {self.block_size} --nsze={ns_number_of_blocks} --ncap={ns_number_of_blocks}")
 

--- a/benchmark/duckdb/device/nvme.py
+++ b/benchmark/duckdb/device/nvme.py
@@ -234,7 +234,7 @@ def calculate_waf(host_written_bytes, media_written_bytes):
 
     return media_written_bytes / host_written_bytes
 
-def setup_device(device: NvmeDevice, namespace_id:int = 1, enable_fdp: bool = False, mount_path: str = None) -> NvmeDeviceNamespace:
+def setup_device(device: NvmeDevice, namespace_id:int = 1, enable_fdp: bool = False, mount_path: str = None, size: float = 0.1) -> NvmeDeviceNamespace:
     """
     Sets up the device by creating a namespace and enabling FDP if required
     """
@@ -253,4 +253,4 @@ def setup_device(device: NvmeDevice, namespace_id:int = 1, enable_fdp: bool = Fa
         device.disable_fdp()
     
     # Create new namespace with a new configuration
-    return device.create_namespace(device.base_device_path, namespace_id, enable_fdp, mount_path=mount_path)
+    return device.create_namespace(device.base_device_path, namespace_id, enable_fdp, mount_path=mount_path, size=size)

--- a/benchmark/duckdb/device/nvme.py
+++ b/benchmark/duckdb/device/nvme.py
@@ -160,7 +160,7 @@ class NvmeDevice:
         
         os.system(f"nvme delete-ns {self.base_device_path} --namespace-id={namespace_id}")
 
-    def create_namespace(self, device_path: str, namespace_id: int, enable_fdp: bool = False, size: float = 1.0, mount_path:str = None):
+    def create_namespace(self, device_path: str, namespace_id: int, enable_fdp: bool = False, mount_path:str = None):
         """
         Creates a namespace on the device and attaches it
 
@@ -240,7 +240,7 @@ def calculate_waf(host_written_bytes, media_written_bytes):
 
     return media_written_bytes / host_written_bytes
 
-def setup_device(device: NvmeDevice, namespace_id:int = 1, enable_fdp: bool = False, mount_path: str = None, size: float = 0.1) -> NvmeDeviceNamespace:
+def setup_device(device: NvmeDevice, namespace_id:int = 1, enable_fdp: bool = False, mount_path: str = None) -> NvmeDeviceNamespace:
     """
     Sets up the device by creating a namespace and enabling FDP if required
     """

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -16,7 +16,7 @@ precondition_device_fdp() {
 
     nvme set-feature $DEVICE_PATH -f 0x1D -c 1 -s
 
-    nvme create-ns $DEVICE_PATH -b 4096 --nsze=$SIZE --ncap=$SIZE
+    nvme create-ns $DEVICE_PATH -b 4096 --nsze=$SIZE --ncap=$SIZE --nphndls=1 --phndls=6
     nvme attach-ns $DEVICE_PATH --namespace-id=1 --controllers=0x7
 
     /home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=256k

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -10,14 +10,28 @@ M_SIZE_PRECONDITION=826334573 # ~3,38TB, 90% of device
 L_SIZE_DEVICE=156085420 # ~639GB, 17% of device
 L_SIZE_PRECONDITION=762064106 # ~3,12TB, 83% of device
 
-precondition_device() {
+precondition_device_fdp() {
     DEVICE_PATH=$1
     SIZE=$2
+
+    nvme set-feature $DEVICE_PATH -f 0x1D -c 1 -s
 
     nvme create-ns $DEVICE_PATH -b 4096 --nsze=$SIZE --ncap=$SIZE
     nvme attach-ns $DEVICE_PATH --namespace-id=1 --controllers=0x7
 
-    /home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=128K
+    /home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=256k
+}
+
+precondition_device() {
+    DEVICE_PATH=$1
+    SIZE=$2
+
+    nvme set-feature $DEVICE_PATH -f 0x1D -c 0 -s
+
+    nvme create-ns $DEVICE_PATH -b 4096 --nsze=$SIZE --ncap=$SIZE
+    nvme attach-ns $DEVICE_PATH --namespace-id=1 --controllers=0x7
+
+    /home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=256k
 }
 
 remove_precondition_device() {
@@ -31,7 +45,7 @@ remove_precondition_device() {
 source /home/pinar/.bashrc
 source ./init.sh
 
-precondition_device $DEVICE $M_SIZE_PRECONDITION
+precondition_device_fdp $DEVICE $M_SIZE_PRECONDITION
 
 python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 500 --sf 100 --fdp tpch
 

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -7,8 +7,6 @@ MOUNT="/mnt/itu/duckdb"
 
 #Max device blocks 91814953
 
-#826334573
-
 M_SIZE_DEVICE=91803153 # ~376GB, 10% of device
 M_SIZE_PRECONDITION=826334568 # ~3,38TB, 90% of device
 L_SIZE_DEVICE=156085420 # ~639GB, 17% of device

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -5,20 +5,52 @@ DEVICE="/dev/nvme1"
 INPUT_DIR="/home/pinar"
 MOUNT="/mnt/itu/duckdb"
 
+M_SIZE_DEVICE=91814953 # ~376GB, 10% of device
+M_SIZE_PRECONDITION=826334573 # ~3,38TB, 90% of device
+L_SIZE_DEVICE=156085420 # ~639GB, 17% of device
+L_SIZE_PRECONDITION=762064106 # ~3,12TB, 83% of device
+
+precondition_device() {
+    DEVICE_PATH=$1
+    SIZE=$2
+
+    nvme create-ns $DEVICE_PATH -b 4096 --nsze=$SIZE --ncap=$SIZE
+    nvme attach-ns $DEVICE_PATH --namespace-id=1 --controllers=0x7
+
+    /home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=128K
+}
+
+remove_precondition_device() {
+    DEVICE_PATH=$1
+    SIZE=$2
+
+    nvme dsm $DEVICE_PATH --namespace-id=1 --ad -s 0 -b $SIZE
+    nvme delete-ns $DEVICE_PATH --namespace-id=1
+}
+
 source /home/pinar/.bashrc
 source ./init.sh
 
+precondition_device $DEVICE $M_SIZE_PRECONDITION
+
+python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 500 --sf 100 --fdp tpch
+
+remove_precondition_device $DEVICE $M_SIZE_PRECONDITION
+precondition_device $DEVICE $M_SIZE_PRECONDITION
+
+python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 500 --sf 100 tpch
+
+remove_precondition_device $DEVICE $M_SIZE_PRECONDITION
+
+
 # Run benchmarks with enough main memory to not make it spill to disk
-python3 benchmark.py -d $READ_DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 50000 tpch
-python3 benchmark.py -d $READ_DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 50000 --fdp tpch
-python3 benchmark.py -d $READ_DURATION --mount_path $MOUNT --device_path $DEVICE --input_directory $INPUT_DIR -m 50000 tpch
+# python3 benchmark.py -d $READ_DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 50000 tpch
+# python3 benchmark.py -d $READ_DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 50000 --fdp tpch
+# python3 benchmark.py -d $READ_DURATION --mount_path $MOUNT --device_path $DEVICE --input_directory $INPUT_DIR -m 50000 tpch
 
 # Run the benchmark with the generic device, io_uring_cmd, and fdp
-python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 75 tpch
-python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 75 --fdp tpch
-
-# Run the benchmark with the nvme block device(e.g. /dev/nvme1n1) using io_uring
-# python3 benchmark.py -i $DURATION -d $DEVICE -b "io_uring" tpch
+# python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 75 tpch
+# python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 75 --fdp tpch
 
 # Run regular benchmark with default file system(could be a base line)
-python3 benchmark.py -d $DURATION --mount_path $MOUNT --device_path $DEVICE --input_directory $INPUT_DIR -m 75 tpch
+# python3 benchmark.py -d $DURATION --mount_path $MOUNT --device_path $DEVICE --input_directory $INPUT_DIR -m 75 tpch

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -19,7 +19,7 @@ precondition_device_fdp() {
     nvme create-ns $DEVICE_PATH -b 4096 --nsze=$SIZE --ncap=$SIZE --nphndls=1 --phndls=6
     nvme attach-ns $DEVICE_PATH --namespace-id=1 --controllers=0x7
 
-    /home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=256k
+    #/home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=256k
 }
 
 precondition_device() {
@@ -31,7 +31,7 @@ precondition_device() {
     nvme create-ns $DEVICE_PATH -b 4096 --nsze=$SIZE --ncap=$SIZE
     nvme attach-ns $DEVICE_PATH --namespace-id=1 --controllers=0x7
 
-    /home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=256k
+    #/home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=256k
 }
 
 remove_precondition_device() {

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -5,8 +5,10 @@ DEVICE="/dev/nvme1"
 INPUT_DIR="/home/pinar"
 MOUNT="/mnt/itu/duckdb"
 
+
+
 M_SIZE_DEVICE=91814953 # ~376GB, 10% of device
-M_SIZE_PRECONDITION=826334573 # ~3,38TB, 90% of device
+M_SIZE_PRECONDITION=826334568 # ~3,38TB, 90% of device
 L_SIZE_DEVICE=156085420 # ~639GB, 17% of device
 L_SIZE_PRECONDITION=762064106 # ~3,12TB, 83% of device
 

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DURATION=180
+DURATION=240
 READ_DURATION=30
 DEVICE="/dev/nvme1"
 INPUT_DIR="/home/pinar"

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -11,7 +11,7 @@ source ./init.sh
 # Run benchmarks with enough main memory to not make it spill to disk
 python3 benchmark.py -d $READ_DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 50000 tpch
 python3 benchmark.py -d $READ_DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 50000 --fdp tpch
-python3 benchmark.py -d $DURATION --mount_path $MOUNT --device_path $DEVICE --input_directory $INPUT_DIR -m 50000 tpch
+python3 benchmark.py -d $READ_DURATION --mount_path $MOUNT --device_path $DEVICE --input_directory $INPUT_DIR -m 50000 tpch
 
 # Run the benchmark with the generic device, io_uring_cmd, and fdp
 python3 benchmark.py -d $DURATION --input_directory $INPUT_DIR --device_path $DEVICE --generic_device -b "io_uring_cmd" -m 75 tpch

--- a/benchmark/duckdb/run.sh
+++ b/benchmark/duckdb/run.sh
@@ -5,9 +5,11 @@ DEVICE="/dev/nvme1"
 INPUT_DIR="/home/pinar"
 MOUNT="/mnt/itu/duckdb"
 
+#Max device blocks 91814953
 
+#826334573
 
-M_SIZE_DEVICE=91814953 # ~376GB, 10% of device
+M_SIZE_DEVICE=91803153 # ~376GB, 10% of device
 M_SIZE_PRECONDITION=826334568 # ~3,38TB, 90% of device
 L_SIZE_DEVICE=156085420 # ~639GB, 17% of device
 L_SIZE_PRECONDITION=762064106 # ~3,12TB, 83% of device
@@ -18,8 +20,11 @@ precondition_device_fdp() {
 
     nvme set-feature $DEVICE_PATH -f 0x1D -c 1 -s
 
-    nvme create-ns $DEVICE_PATH -b 4096 --nsze=$SIZE --ncap=$SIZE --nphndls=1 --phndls=6
-    nvme attach-ns $DEVICE_PATH --namespace-id=1 --controllers=0x7
+    sudo nvme create-ns /dev/nvme1 -b 4096 --nsze=826334573 --ncap=826334573 --nphndls=1 --phndls=0 && \
+    sudo nvme attach-ns /dev/nvme1 --namespace-id=1 --controllers=0x7
+
+    sudo nvme create-ns /dev/nvme1 -b 4096 --nsze=91814953 --ncap=91814953 --nphndls=7 --phndls=1,2,3,4,5,6,7 && \
+    sudo nvme attach-ns /dev/nvme1 --namespace-id=2 --controllers=0x7
 
     #/home/pinar/.local/fio/fio --filename=/dev/ng1n1 --size="100%" --name fillDevice --rw=write --numjobs=1 --ioengine=io_uring_cmd --iodepth=64 --bs=256k
 }

--- a/benchmark/duckdb/runner/tpch.py
+++ b/benchmark/duckdb/runner/tpch.py
@@ -21,15 +21,16 @@ def run_tpch_epoch_benchmark(db: Database):
 
     results: list[str] = []
 
-    for query_nr in range(1, 22):
-        start = time.perf_counter()
-        print(f"Running TPCH query {query_nr}...")
-        db.query(f"PRAGMA tpch({query_nr});")
-        end = time.perf_counter()
+    query_nr = 9
+    # for query_nr in range(1, 22):
+    start = time.perf_counter()
+    print(f"Running TPCH query {query_nr}...")
+    db.query(f"PRAGMA tpch({query_nr});")
+    end = time.perf_counter()
 
-        # Get query elapsed time in milliseconds
-        query_elapsed = (end - start) * 1000
+    # Get query elapsed time in milliseconds
+    query_elapsed = (end - start) * 1000
 
-        results.append(f"{query_nr};{query_elapsed}\n")
+    results.append(f"{query_nr};{query_elapsed}\n")
 
     return results


### PR DESCRIPTION

- **Fix missing READ in front of duration**
- **Change the device allocation to be for namespace 2**
- **Add preconditioning of device**
- **Set the default size of the device to 10%**
- **Bump nvmefs**
- **Limit to only one query**
- **Let the script precondition the device**
- **Change the amount of handles allowed**
- **Increase duration to 4 hours**
- **remove precondition**
- **Fix allocation size**
- **fix benchmark to have the correct block size**
- **Remove comment**
- **Get total and unallocated blocks**
- **Remove the size from arguments list**
